### PR TITLE
case-insensitive-enums

### DIFF
--- a/src/utils/pybind11/ImplicitStringToEnumConversion.h
+++ b/src/utils/pybind11/ImplicitStringToEnumConversion.h
@@ -31,8 +31,9 @@ void make_implicitly_convertible_from_string(pybind11::enum_<Type> &enumType)
 	enumType.def(pybind11::init([enumType](pybind11::str value)
 	                            {
 		                            auto values = pybind11::dict(enumType.attr("__members__"));
-		                            if (values.contains(value)) {
-			                            return pybind11::cast<Type>(values[value]);
+									auto key = value.attr("upper")();
+		                            if (values.contains(key)) {
+			                            return pybind11::cast<Type>(values[key]);
 		                            }
 
 		                            throw pybind11::value_error("\"" + pybind11::cast<std::string>(value) + "\" is not a valid value for enum type " + pybind11::cast<std::string>(enumType.attr("__name__")));

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,7 @@
+import numpy as np
+import parselmouth as pm
+
+def test_case(sound):
+    pitch = sound.to_pitch("CC")
+    pitch = sound.to_pitch("cc")
+    


### PR DESCRIPTION
Yannick,

Here is a quick take on making Praat enums case-insensitive.

Donno if this is the direction you'd like to take, but it's an easy mod. Take a look.

P.S., `test_enums.py` was added more for my verification and demonstration to you. Feel free to delete it if you decide to add this feature.