### PR TITLE
Support msvc-dev-cmd locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=42",
     "cmake>=3.18",
     "scikit-build>=0.13",
+    "vswhere; os_name=='nt'"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy>=1.7
+vswhere; os_name=='nt'


### PR DESCRIPTION
I had to refresh my memory on how to build the project on Windows after so many years of inactivity. lol

In process of doing so, I decided to make the local Windows build process a little easier. Using MSVS C++, the project cannot currently be installed from source (`pip install .`) from a plain command line because VC++ environment is not set.

This PR pulled the mechanism from `ilammy/msvc-dev-cmd` CI tool into `setup.py` so that the VC++ environment is set locally as does in CI.
