### PR TITLE
Support using system CMake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "cmake>=3.18",
     "scikit-build>=0.13",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import io
 import os
 import re
 import shlex
+import shutil
 import sys
 
 try:
@@ -37,11 +38,17 @@ def find_version(*file_paths):
 	raise RuntimeError("Unable to find version string.")
 
 
+setup_requires = []
+if shutil.which("cmake") is None:
+	setup_requires += ["cmake>=3.18"]
+
+
 setup(
 	version=find_version(),
 	packages=[''],
 	package_dir={'': "src"},
 	include_package_data=False,
+	setup_requires=setup_requires,
 	cmake_args=shlex.split(os.environ.get('PARSELMOUTH_EXTRA_CMAKE_ARGS', '')),
 	cmake_install_dir="src",
 )


### PR DESCRIPTION
Add dependencies on `cmake` PyPI package only if the `cmake` executable is not available, in order to support using system CMake.  This avoids an unnecessary dependency on a third-party binary package, and improves portability by permitting downstream-packaged CMake with additional platform support patches.