### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/praat/external/opusfile/opusfile.cpp
+++ b/praat/external/opusfile/opusfile.cpp
@@ -141,6 +141,7 @@ static int op_get_data(OggOpusFile *_of,int _nbytes){
   int            nbytes;
   OP_ASSERT(_nbytes>0);
   buffer=(unsigned char *)ogg_sync_buffer(&_of->oy,_nbytes);
+  if(OP_UNLIKELY(buffer==NULL))return OP_EFAULT;
   nbytes=(int)(*_of->callbacks.read)(_of->stream,buffer,_nbytes);
   OP_ASSERT(nbytes<=_nbytes);
   if(OP_LIKELY(nbytes>0))ogg_sync_wrote(&_of->oy,nbytes);
@@ -1520,6 +1521,7 @@ static int op_open1(OggOpusFile *_of,
   if(_initial_bytes>0){
     char *buffer;
     buffer=ogg_sync_buffer(&_of->oy,(long)_initial_bytes);
+    if(OP_UNLIKELY(buffer==NULL))return OP_EFAULT;
     memcpy(buffer,_initial_data,_initial_bytes*sizeof(*buffer));
     ogg_sync_wrote(&_of->oy,(long)_initial_bytes);
   }


### PR DESCRIPTION
Hi Development Team,

I identified potential vulnerabilities in clone functions in `praat/external/opusfile/opusfile.cpp` sourced from [xiph/opusfile](https://github.com/xiph/opusfile). This issue, originally reported in [CVE-2022-47021](https://nvd.nist.gov/vuln/detail/CVE-2022-47021), was resolved in the repository via this commit https://github.com/xiph/opusfile/commit/0a4cd796df5b030cb866f3f4a5e41a4b92caddf5.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!